### PR TITLE
Add umami analytics tracking

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ pygmentsstyle = "vs"
 pygmentscodefences = true
 pygmentscodefencesguesssyntax = true
 
-googleAnalytics = "UA-123-45"
+# googleAnalytics = "UA-123-45"  # Removed - using self-hosted umami at analytics.lasse.be
 ignoreLogs = ['warning-goldmark-raw-html']
 
 [markup]

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -16,3 +16,9 @@
 {{ if eq .RelPermalink "/about/" }}
 <link rel="stylesheet" href="{{ "css/about-page.css" | absURL }}">
 {{ end }}
+
+{{- /* Umami Analytics - only in production */ -}}
+{{- if not .Site.IsServer -}}
+<script defer src="https://changed.lasse.be/script.js" data-website-id="6fa18ad1-a190-418d-a229-292dc477ec5f"></script>
+<script src="{{ "js/scroll-tracking.js" | absURL }}" defer></script>
+{{- end -}}

--- a/static/js/scroll-tracking.js
+++ b/static/js/scroll-tracking.js
@@ -1,0 +1,34 @@
+// Scroll depth tracking for umami analytics
+(function() {
+  'use strict';
+
+  let scrollMarks = { 25: false, 50: false, 75: false, 100: false };
+  let ticking = false;
+
+  function trackScrollDepth() {
+    const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+
+    if (scrollHeight <= 0) return;
+
+    const scrollPercent = Math.round((window.scrollY / scrollHeight) * 100);
+
+    [25, 50, 75, 100].forEach(function(mark) {
+      if (scrollPercent >= mark && !scrollMarks[mark]) {
+        scrollMarks[mark] = true;
+        if (typeof umami !== 'undefined') {
+          umami.track('scroll-' + mark);
+        }
+      }
+    });
+  }
+
+  window.addEventListener('scroll', function() {
+    if (!ticking) {
+      window.requestAnimationFrame(function() {
+        trackScrollDepth();
+        ticking = false;
+      });
+      ticking = true;
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- Add self-hosted umami analytics tracking (replaces Google Analytics)
- Add scroll depth tracking (25%, 50%, 75%, 100%)
- Tracking only loads in production, not during local development

## Changes
- `layouts/partials/extend_head.html` - umami script + scroll tracking
- `static/js/scroll-tracking.js` - scroll depth events
- `config.toml` - commented out GA

🤖 Generated with [Claude Code](https://claude.ai/claude-code)